### PR TITLE
Fix Geometry WKB parsing issue For MultiPoint ZM geometry

### DIFF
--- a/src/main/java/com/esri/core/geometry/OperatorExportToWkbLocal.java
+++ b/src/main/java/com/esri/core/geometry/OperatorExportToWkbLocal.java
@@ -750,7 +750,7 @@ class OperatorExportToWkbLocal extends OperatorExportToWkb {
 			if ((exportFlags & WkbExportFlags.wkbExportPoint) == 0) {
 				wkbBuffer.put(offset, byteOrder);
 				offset += 1;
-				wkbBuffer.putInt(offset, WkbGeometryType.wkbMultiPolygonZM);
+				wkbBuffer.putInt(offset, WkbGeometryType.wkbMultiPointZM);
 				offset += 4;
 				wkbBuffer.putInt(offset, point_count);
 				offset += 4;

--- a/src/test/java/com/esri/core/geometry/TestWKBSupport.java
+++ b/src/test/java/com/esri/core/geometry/TestWKBSupport.java
@@ -24,6 +24,7 @@
 
 package com.esri.core.geometry;
 
+import com.esri.core.geometry.ogc.OGCGeometry;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import junit.framework.TestCase;
@@ -107,4 +108,12 @@ public class TestWKBSupport extends TestCase {
 
 	}
 
+	@Test
+	public void testWKB3() throws Exception {
+		String multiPointWKT = "MULTIPOINT ZM(10 40 1 23, 40 30 2 45)";
+		OGCGeometry geometry = OGCGeometry.fromText(multiPointWKT);
+		ByteBuffer byteBuffer = geometry.asBinary();
+		OGCGeometry geomFromBinary = OGCGeometry.fromBinary(byteBuffer);
+		assertTrue(geometry.Equals(geomFromBinary));
+	}
 }


### PR DESCRIPTION
Geometry with MultiPoint ZM not getting generated by WKB exporter e.g. `MULTIPOINT ZM(10 40 1 23, 40 30 2 45)`